### PR TITLE
new: Set `PATH` env var when running binaries.

### DIFF
--- a/crates/toolchain/src/lib.rs
+++ b/crates/toolchain/src/lib.rs
@@ -5,5 +5,6 @@ mod toolchain;
 pub mod tools;
 
 pub use errors::ToolchainError;
+pub use helpers::get_path_env_var;
 pub use tool::Tool;
 pub use toolchain::Toolchain;

--- a/crates/toolchain/src/tool.rs
+++ b/crates/toolchain/src/tool.rs
@@ -6,6 +6,11 @@ use std::process::Output;
 
 #[async_trait]
 pub trait Tool {
+    /// Returns an absolute file path to the directory containing the executable binaries.
+    fn get_bin_dir(&self) -> PathBuf {
+        self.get_bin_path().parent().unwrap().to_path_buf()
+    }
+
     /// Returns an absolute file path to the executable binary for the tool.
     /// This _may not exist_, as the path is composed ahead of time.
     fn get_bin_path(&self) -> &PathBuf;

--- a/crates/toolchain/src/toolchain.rs
+++ b/crates/toolchain/src/toolchain.rs
@@ -274,19 +274,4 @@ impl Toolchain {
             None => None,
         }
     }
-
-    /// We need to ensure that our toolchain binaries are executed instead of
-    /// other binaries of the same name. Otherwise, tooling like nvm will
-    /// intercept execution and break our processes. We can work around this
-    /// by prepending the `PATH` environment variable.
-    pub fn get_path_env_var(&self) -> std::ffi::OsString {
-        use std::env;
-
-        let path = env::var("PATH").unwrap_or_default();
-        let mut paths = vec![self.get_node().get_bin_dir()];
-
-        paths.extend(env::split_paths(&path).collect::<Vec<_>>());
-
-        env::join_paths(paths).unwrap()
-    }
 }

--- a/crates/toolchain/src/toolchain.rs
+++ b/crates/toolchain/src/toolchain.rs
@@ -274,4 +274,19 @@ impl Toolchain {
             None => None,
         }
     }
+
+    /// We need to ensure that our toolchain binaries are executed instead of
+    /// other binaries of the same name. Otherwise, tooling like nvm will
+    /// intercept execution and break our processes. We can work around this
+    /// by prepending the `PATH` environment variable.
+    pub fn get_path_env_var(&self) -> std::ffi::OsString {
+        use std::env;
+
+        let path = env::var("PATH").unwrap_or_default();
+        let mut paths = vec![self.get_node().get_bin_dir()];
+
+        paths.extend(env::split_paths(&path).collect::<Vec<_>>());
+
+        env::join_paths(paths).unwrap()
+    }
 }

--- a/crates/toolchain/src/tools/node.rs
+++ b/crates/toolchain/src/tools/node.rs
@@ -198,6 +198,10 @@ impl NodeTool {
         self.find_package_bin_path(package_name, starting_dir.parent().unwrap())
     }
 
+    pub fn get_bin_dir(&self) -> PathBuf {
+        self.bin_path.parent().unwrap().to_path_buf()
+    }
+
     pub fn is_corepack_aware(&self) -> bool {
         let min_version = VersionReq::parse(">=16.9.0").unwrap();
         let cfg_version = Version::parse(&self.config.version).unwrap();

--- a/crates/toolchain/src/tools/node.rs
+++ b/crates/toolchain/src/tools/node.rs
@@ -1,5 +1,7 @@
 use crate::errors::ToolchainError;
-use crate::helpers::{download_file_from_url, get_bin_version, get_file_sha256_hash};
+use crate::helpers::{
+    download_file_from_url, get_bin_version, get_file_sha256_hash, get_path_env_var,
+};
 use crate::tool::Tool;
 use crate::Toolchain;
 use async_trait::async_trait;
@@ -167,7 +169,12 @@ impl NodeTool {
         I: IntoIterator<Item = S>,
         S: AsRef<OsStr>,
     {
-        Ok(exec_command(create_command(&self.corepack_bin_path).args(args)).await?)
+        Ok(exec_command(
+            create_command(&self.corepack_bin_path)
+                .args(args)
+                .env("PATH", get_path_env_var(self.get_bin_dir())),
+        )
+        .await?)
     }
 
     pub fn find_package_bin_path(
@@ -196,10 +203,6 @@ impl NodeTool {
         }
 
         self.find_package_bin_path(package_name, starting_dir.parent().unwrap())
-    }
-
-    pub fn get_bin_dir(&self) -> PathBuf {
-        self.bin_path.parent().unwrap().to_path_buf()
     }
 
     pub fn is_corepack_aware(&self) -> bool {

--- a/crates/toolchain/src/tools/npm.rs
+++ b/crates/toolchain/src/tools/npm.rs
@@ -1,5 +1,5 @@
 use crate::errors::ToolchainError;
-use crate::helpers::{get_bin_version, is_ci};
+use crate::helpers::{get_bin_version, get_path_env_var, is_ci};
 use crate::tool::{PackageManager, Tool};
 use crate::Toolchain;
 use async_trait::async_trait;
@@ -151,7 +151,8 @@ impl PackageManager for NpmTool {
         Ok(exec_command(
             create_command(self.get_bin_path())
                 .args(["dedupe"])
-                .current_dir(&toolchain.workspace_root),
+                .current_dir(&toolchain.workspace_root)
+                .env("PATH", get_path_env_var(self.get_bin_dir())),
         )
         .await?)
     }
@@ -169,7 +170,8 @@ impl PackageManager for NpmTool {
         Ok(exec_command(
             create_command(&self.npx_path)
                 .args(exec_args)
-                .current_dir(&toolchain.workspace_root),
+                .current_dir(&toolchain.workspace_root)
+                .env("PATH", get_path_env_var(self.get_bin_dir())),
         )
         .await?)
     }
@@ -187,7 +189,8 @@ impl PackageManager for NpmTool {
         Ok(exec_command(
             create_command(self.get_bin_path())
                 .args([if is_ci() { "ci" } else { "install" }])
-                .current_dir(&toolchain.workspace_root),
+                .current_dir(&toolchain.workspace_root)
+                .env("PATH", get_path_env_var(self.get_bin_dir())),
         )
         .await?)
     }

--- a/crates/toolchain/src/tools/pnpm.rs
+++ b/crates/toolchain/src/tools/pnpm.rs
@@ -1,5 +1,5 @@
 use crate::errors::ToolchainError;
-use crate::helpers::{get_bin_version, is_ci};
+use crate::helpers::{get_bin_version, get_path_env_var, is_ci};
 use crate::tool::{PackageManager, Tool};
 use crate::Toolchain;
 use async_trait::async_trait;
@@ -136,7 +136,8 @@ impl PackageManager for PnpmTool {
         Ok(exec_command(
             create_command(self.get_bin_path())
                 .args(["prune"])
-                .current_dir(&toolchain.workspace_root),
+                .current_dir(&toolchain.workspace_root)
+                .env("PATH", get_path_env_var(self.get_bin_dir())),
         )
         .await?)
     }
@@ -155,7 +156,8 @@ impl PackageManager for PnpmTool {
         Ok(exec_command(
             create_command(self.get_bin_path())
                 .args(exec_args)
-                .current_dir(&toolchain.workspace_root),
+                .current_dir(&toolchain.workspace_root)
+                .env("PATH", get_path_env_var(self.get_bin_dir())),
         )
         .await?)
     }
@@ -179,7 +181,8 @@ impl PackageManager for PnpmTool {
         Ok(exec_command(
             create_command(self.get_bin_path())
                 .args(args)
-                .current_dir(&toolchain.workspace_root),
+                .current_dir(&toolchain.workspace_root)
+                .env("PATH", get_path_env_var(self.get_bin_dir())),
         )
         .await?)
     }

--- a/crates/toolchain/src/tools/yarn.rs
+++ b/crates/toolchain/src/tools/yarn.rs
@@ -1,5 +1,5 @@
 use crate::errors::ToolchainError;
-use crate::helpers::{get_bin_version, is_ci};
+use crate::helpers::{get_bin_version, get_path_env_var, is_ci};
 use crate::tool::{PackageManager, Tool};
 use crate::Toolchain;
 use async_trait::async_trait;
@@ -144,7 +144,8 @@ impl Tool for YarnTool {
             exec_command(
                 create_command(self.get_bin_path())
                     .args(["set", "version", &self.config.version])
-                    .current_dir(&toolchain.workspace_root),
+                    .current_dir(&toolchain.workspace_root)
+                    .env("PATH", get_path_env_var(self.get_bin_dir())),
             )
             .await?;
         }
@@ -189,7 +190,8 @@ impl PackageManager for YarnTool {
             Ok(exec_command(
                 create_command(self.get_bin_path())
                     .args(["dedupe"])
-                    .current_dir(&toolchain.workspace_root),
+                    .current_dir(&toolchain.workspace_root)
+                    .env("PATH", get_path_env_var(self.get_bin_dir())),
             )
             .await?)
         }
@@ -209,7 +211,8 @@ impl PackageManager for YarnTool {
         Ok(exec_command(
             create_command(self.get_bin_path())
                 .args(exec_args)
-                .current_dir(&toolchain.workspace_root),
+                .current_dir(&toolchain.workspace_root)
+                .env("PATH", get_path_env_var(self.get_bin_dir())),
         )
         .await?)
     }
@@ -250,7 +253,8 @@ impl PackageManager for YarnTool {
         Ok(exec_command(
             create_command(self.get_bin_path())
                 .args(args)
-                .current_dir(&toolchain.workspace_root),
+                .current_dir(&toolchain.workspace_root)
+                .env("PATH", get_path_env_var(self.get_bin_dir())),
         )
         .await?)
     }

--- a/crates/workspace/src/tasks/run_target.rs
+++ b/crates/workspace/src/tasks/run_target.rs
@@ -4,7 +4,7 @@ use moon_config::TaskType;
 use moon_logger::debug;
 use moon_project::{Project, Target, Task};
 use moon_toolchain::tools::node::NodeTool;
-use moon_toolchain::Tool;
+use moon_toolchain::{get_path_env_var, Tool};
 use moon_utils::process::{exec_command, output_to_string, Output};
 use std::collections::HashMap;
 use std::path::Path;
@@ -78,13 +78,14 @@ async fn run_node_target(
         package_bin_path.to_str().unwrap(),
     ];
 
-    // Node module args
+    // Package args
     args.extend(task.args.iter().map(|a| a.as_str()));
 
     Ok(exec_command(
         Command::new(node.get_bin_path())
             .args(&args)
             .current_dir(&exec_dir)
+            .env("PATH", get_path_env_var(node.get_bin_dir()))
             .envs(env_vars),
     )
     .await?)

--- a/yarn.lock
+++ b/yarn.lock
@@ -2287,10 +2287,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:*":
-  version: 17.0.13
-  resolution: "@types/node@npm:17.0.13"
-  checksum: 8b87c850c1604c65e3474bd03d122914464b7970caed20f65f4a7706ab429353b896a3916be4d2581164eccda9e3dd95c338fbccf686ff85a824c40d15e8f3fa
+"@types/node@npm:*, @types/node@npm:^17.0.15":
+  version: 17.0.15
+  resolution: "@types/node@npm:17.0.15"
+  checksum: aa64ecf4fbcf9888e794dcdc20e98c49cdcb102b17e57c44ca56943904732d6cc250e766f8448a3cd71d6a40a4b597bd83c565e5bd9b982733fa3f9813d5c291
   languageName: node
   linkType: hard
 
@@ -2298,13 +2298,6 @@ __metadata:
   version: 12.20.24
   resolution: "@types/node@npm:12.20.24"
   checksum: e7a13460e2f5b0b5a32c0f3af7daf1a05201552a66d542d3cc3b1ea8b52d4730250f9eb1961d755e31cfe5d03c78340911a6242657a0a9a17d6f7e341fc9f366
-  languageName: node
-  linkType: hard
-
-"@types/node@npm:^17.0.15":
-  version: 17.0.15
-  resolution: "@types/node@npm:17.0.15"
-  checksum: aa64ecf4fbcf9888e794dcdc20e98c49cdcb102b17e57c44ca56943904732d6cc250e766f8448a3cd71d6a40a4b597bd83c565e5bd9b982733fa3f9813d5c291
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Otherwise nvm shims would take precedence and break our runner.