### PR TITLE
new: Defer version checks of package managers.

### DIFF
--- a/crates/cache/src/engine.rs
+++ b/crates/cache/src/engine.rs
@@ -258,7 +258,8 @@ mod tests {
             assert_eq!(
                 item.item,
                 WorkspaceState {
-                    last_node_install_time: 123
+                    last_node_install_time: 123,
+                    last_version_check_time: 0,
                 }
             );
 

--- a/crates/cache/src/items.rs
+++ b/crates/cache/src/items.rs
@@ -62,5 +62,9 @@ pub struct RunTargetState {
 #[derive(Debug, Default, Deserialize, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct WorkspaceState {
+    #[serde(default)]
     pub last_node_install_time: u128,
+
+    #[serde(default)]
+    pub last_version_check_time: u128,
 }

--- a/crates/cli/src/commands/bin.rs
+++ b/crates/cli/src/commands/bin.rs
@@ -37,7 +37,7 @@ pub async fn bin(tool_type: &BinTools) -> Result<(), Box<dyn std::error::Error>>
         },
     };
 
-    let installed = tool.is_installed().await;
+    let installed = tool.is_installed(true).await;
 
     if installed.is_err() || !installed.unwrap() {
         safe_exit(BinExitCodes::NotInstalled as i32);

--- a/crates/cli/src/commands/setup.rs
+++ b/crates/cli/src/commands/setup.rs
@@ -4,7 +4,7 @@ pub async fn setup() -> Result<(), Box<dyn std::error::Error>> {
     let workspace = Workspace::load().await?;
     let mut root_package = workspace.load_package_json().await?;
 
-    workspace.toolchain.setup(&mut root_package).await?;
+    workspace.toolchain.setup(&mut root_package, true).await?;
 
     Ok(())
 }

--- a/crates/toolchain/src/tool.rs
+++ b/crates/toolchain/src/tool.rs
@@ -28,7 +28,9 @@ pub trait Tool {
     fn get_download_path(&self) -> Option<&PathBuf>;
 
     /// Determine whether the tool has already been installed.
-    async fn is_installed(&self) -> Result<bool, ToolchainError>;
+    /// If `check_version` is false, avoid running the binaries as child processes
+    /// to extract the current version.
+    async fn is_installed(&self, check_version: bool) -> Result<bool, ToolchainError>;
 
     /// Runs any installation steps after downloading.
     /// This is typically unzipping an archive, and running any installers/binaries.

--- a/crates/toolchain/src/tools/node.rs
+++ b/crates/toolchain/src/tools/node.rs
@@ -280,28 +280,18 @@ impl Tool for NodeTool {
 
     async fn is_installed(&self, _check_version: bool) -> Result<bool, ToolchainError> {
         if self.install_dir.exists() {
-            let version = self.get_installed_version().await?;
-
-            if version == self.config.version {
-                debug!(
-                    target: "moon:toolchain:node",
-                    "Download has already been installed and is on the correct version",
-                );
-
-                return Ok(true);
-            }
-
             debug!(
                 target: "moon:toolchain:node",
-                "Download has been installed, but is on the wrong version ({}), attempting to reinstall",
-                version,
+                "Download has already been installed and is on the correct version",
             );
-        } else {
-            debug!(
-                target: "moon:toolchain:node",
-                "Download has not been installed",
-            );
+
+            return Ok(true);
         }
+
+        debug!(
+            target: "moon:toolchain:node",
+            "Download has not been installed",
+        );
 
         Ok(false)
     }

--- a/crates/toolchain/src/tools/node.rs
+++ b/crates/toolchain/src/tools/node.rs
@@ -278,7 +278,7 @@ impl Tool for NodeTool {
         Ok(())
     }
 
-    async fn is_installed(&self) -> Result<bool, ToolchainError> {
+    async fn is_installed(&self, _check_version: bool) -> Result<bool, ToolchainError> {
         if self.install_dir.exists() {
             let version = self.get_installed_version().await?;
 

--- a/crates/toolchain/src/tools/npm.rs
+++ b/crates/toolchain/src/tools/npm.rs
@@ -79,8 +79,12 @@ impl Tool for NpmTool {
         Ok(()) // This is handled by node
     }
 
-    async fn is_installed(&self) -> Result<bool, ToolchainError> {
+    async fn is_installed(&self, check_version: bool) -> Result<bool, ToolchainError> {
         if self.bin_path.exists() {
+            if !check_version {
+                return Ok(true);
+            }
+
             let version = self.get_installed_version().await?;
 
             if self.config.version == "inherit" {

--- a/crates/toolchain/src/tools/pnpm.rs
+++ b/crates/toolchain/src/tools/pnpm.rs
@@ -59,8 +59,12 @@ impl Tool for PnpmTool {
         Ok(()) // This is handled by node
     }
 
-    async fn is_installed(&self) -> Result<bool, ToolchainError> {
+    async fn is_installed(&self, check_version: bool) -> Result<bool, ToolchainError> {
         if self.bin_path.exists() {
+            if !check_version {
+                return Ok(true);
+            }
+
             let version = self.get_installed_version().await?;
 
             if version == self.config.version {

--- a/crates/toolchain/src/tools/yarn.rs
+++ b/crates/toolchain/src/tools/yarn.rs
@@ -63,8 +63,12 @@ impl Tool for YarnTool {
         Ok(()) // This is handled by node
     }
 
-    async fn is_installed(&self) -> Result<bool, ToolchainError> {
+    async fn is_installed(&self, check_version: bool) -> Result<bool, ToolchainError> {
         if self.bin_path.exists() {
+            if !check_version {
+                return Ok(true);
+            }
+
             let version = self.get_installed_version().await?;
 
             if version == self.config.version {

--- a/crates/workspace/src/tasks/setup_toolchain.rs
+++ b/crates/workspace/src/tasks/setup_toolchain.rs
@@ -4,6 +4,11 @@ use moon_logger::debug;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
+const SECOND: u128 = 1000;
+const MINUTE: u128 = SECOND * 60;
+const HOUR: u128 = MINUTE * 60;
+const DAY: u128 = HOUR * 24;
+
 pub async fn setup_toolchain(workspace: Arc<RwLock<Workspace>>) -> Result<(), WorkspaceError> {
     debug!(
         target: "moon:task-runner:setup-toolchain",
@@ -11,9 +16,26 @@ pub async fn setup_toolchain(workspace: Arc<RwLock<Workspace>>) -> Result<(), Wo
     );
 
     let workspace = workspace.read().await;
+    let mut cache = workspace.cache.cache_workspace_state().await?;
     let mut root_package = workspace.load_package_json().await?;
 
-    workspace.toolchain.setup(&mut root_package).await?;
+    // Only check the versions of some tools every 24 hours,
+    // as checking every run has considerable overhead spawning all
+    // the child processes. Revisit the threshold if need be.
+    let now = cache.now_millis();
+    let check_versions = cache.item.last_version_check_time == 0
+        || (cache.item.last_version_check_time + DAY) <= now;
+
+    workspace
+        .toolchain
+        .setup(&mut root_package, check_versions)
+        .await?;
+
+    // Update the cache with the timestamp
+    if check_versions {
+        cache.item.last_version_check_time = now;
+        cache.save().await?;
+    }
 
     Ok(())
 }

--- a/crates/workspace/src/tasks/setup_toolchain.rs
+++ b/crates/workspace/src/tasks/setup_toolchain.rs
@@ -7,7 +7,6 @@ use tokio::sync::RwLock;
 const SECOND: u128 = 1000;
 const MINUTE: u128 = SECOND * 60;
 const HOUR: u128 = MINUTE * 60;
-const DAY: u128 = HOUR * 24;
 
 pub async fn setup_toolchain(workspace: Arc<RwLock<Workspace>>) -> Result<(), WorkspaceError> {
     debug!(
@@ -19,12 +18,12 @@ pub async fn setup_toolchain(workspace: Arc<RwLock<Workspace>>) -> Result<(), Wo
     let mut cache = workspace.cache.cache_workspace_state().await?;
     let mut root_package = workspace.load_package_json().await?;
 
-    // Only check the versions of some tools every 24 hours,
+    // Only check the versions of some tools every 12 hours,
     // as checking every run has considerable overhead spawning all
     // the child processes. Revisit the threshold if need be.
     let now = cache.now_millis();
     let check_versions = cache.item.last_version_check_time == 0
-        || (cache.item.last_version_check_time + DAY) <= now;
+        || (cache.item.last_version_check_time + HOUR * 12) <= now;
 
     workspace
         .toolchain


### PR DESCRIPTION
Running `--version` as a child process on every run adds considerable overhead, so only do this once every 12 hours (basically once every work day).