### PR TITLE
new: Support a string value for task `args`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1073,6 +1073,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "shell-words",
  "tokio",
  "validator",
 ]
@@ -1785,6 +1786,12 @@ dependencies = [
  "cpufeatures",
  "digest",
 ]
+
+[[package]]
+name = "shell-words"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
 
 [[package]]
 name = "signal-hook-registry"

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -23,6 +23,7 @@ semver = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
 serde_yaml = "0.8"
+shell-words = "1.1"
 validator = { version = "0.14", features = ["derive"] }
 
 [dev-dependencies]

--- a/crates/config/src/project/task.rs
+++ b/crates/config/src/project/task.rs
@@ -1,8 +1,10 @@
 use crate::types::{FilePath, FilePathOrGlob, TargetID};
 use crate::validators::{validate_child_or_root_path, validate_target};
 use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
+use serde::de::{self, SeqAccess};
+use serde::{Deserialize, Deserializer, Serialize};
 use std::collections::HashMap;
+use std::fmt;
 use validator::{Validate, ValidationError};
 
 // These structs utilize optional fields so that we can handle merging effectively,
@@ -96,6 +98,8 @@ impl Default for TaskOptionsConfig {
 
 #[derive(Clone, Debug, Default, Deserialize, JsonSchema, PartialEq, Serialize, Validate)]
 pub struct TaskConfig {
+    #[serde(default)]
+    #[serde(deserialize_with = "deserialize_args")]
     pub args: Option<Vec<String>>,
 
     pub command: Option<String>,
@@ -118,6 +122,48 @@ pub struct TaskConfig {
     #[serde(default)]
     #[serde(rename = "type")]
     pub type_of: TaskType,
+}
+
+// SERDE
+
+struct DeserializeArgs;
+
+impl<'de> de::Visitor<'de> for DeserializeArgs {
+    type Value = Vec<String>;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("a sequence of strings or a string")
+    }
+
+    fn visit_seq<V>(self, mut visitor: V) -> Result<Self::Value, V::Error>
+    where
+        V: SeqAccess<'de>,
+    {
+        let mut vec = Vec::new();
+
+        while let Some(elem) = visitor.next_element()? {
+            vec.push(elem);
+        }
+
+        Ok(vec)
+    }
+
+    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        match shell_words::split(value) {
+            Ok(args) => Ok(args),
+            Err(error) => Err(E::custom(error)),
+        }
+    }
+}
+
+fn deserialize_args<'de, D>(deserializer: D) -> Result<Option<Vec<String>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    Ok(Some(deserializer.deserialize_any(DeserializeArgs)?))
 }
 
 #[cfg(test)]
@@ -169,7 +215,7 @@ mod tests {
     mod args {
         #[test]
         #[should_panic(
-            expected = "Invalid field `args`. Expected a sequence type, received string \"abc\"."
+            expected = "Invalid field `args`. Expected a sequence of strings or a string type, received unsigned int `123`."
         )]
         fn invalid_type() {
             figment::Jail::expect_with(|jail| {
@@ -177,7 +223,7 @@ mod tests {
                     super::CONFIG_FILENAME,
                     r#"
 command: foo
-args: abc
+args: 123
 "#,
                 )?;
 


### PR DESCRIPTION
A little bit cleaner for consumers.