### PR TITLE
fix: Cleanup ANSI usage.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1123,7 +1123,6 @@ dependencies = [
 name = "moon_terminal"
 version = "0.1.0"
 dependencies = [
- "ansi_term",
  "console",
  "lazy_static",
  "moon_logger",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1092,8 +1092,8 @@ dependencies = [
 name = "moon_logger"
 version = "0.1.0"
 dependencies = [
- "ansi_term",
  "chrono",
+ "console",
  "fern",
  "log",
 ]

--- a/crates/cli/src/commands/ci.rs
+++ b/crates/cli/src/commands/ci.rs
@@ -67,7 +67,7 @@ async fn gather_touched_files(
         .all
         .iter()
         .map(|f| {
-            touched_files_to_print.push(format!("  {}", color::path(f)));
+            touched_files_to_print.push(format!("  {}", color::file(f)));
             workspace.root.join(fs::normalize_separators(f))
         })
         .collect();

--- a/crates/cli/src/commands/init.rs
+++ b/crates/cli/src/commands/init.rs
@@ -18,7 +18,7 @@ pub async fn init(dest: &str, force: bool) -> Result<(), Box<dyn std::error::Err
     if moon_dir.exists() && !force {
         println!(
             "Moon has already been initialized in {} (pass {} to overwrite)",
-            color::file_path(&dest_dir.canonicalize().unwrap()),
+            color::path(&dest_dir.canonicalize().unwrap()),
             color::shell("--force")
         );
 
@@ -56,7 +56,7 @@ pub async fn init(dest: &str, force: bool) -> Result<(), Box<dyn std::error::Err
 
     println!(
         "Moon has successfully been initialized in {}",
-        color::file_path(&dest_dir.canonicalize().unwrap()),
+        color::path(&dest_dir.canonicalize().unwrap()),
     );
 
     Ok(())

--- a/crates/cli/src/commands/project.rs
+++ b/crates/cli/src/commands/project.rs
@@ -20,11 +20,11 @@ pub async fn project(id: &str, json: bool) -> Result<(), Box<dyn std::error::Err
     term.write_line("")?;
     term.render_label(Label::Brand, &project.id)?;
     term.render_entry("ID", &color::id(&project.id))?;
-    term.render_entry("Source", &color::path(&project.source))?;
+    term.render_entry("Source", &color::file(&project.source))?;
 
     // Dont show in test snapshots
     if env::var("MOON_TEST").is_err() {
-        term.render_entry("Root", &color::file_path(&project.root))?;
+        term.render_entry("Root", &color::path(&project.root))?;
     }
 
     if let Some(config) = project.config {
@@ -46,7 +46,7 @@ pub async fn project(id: &str, json: bool) -> Result<(), Box<dyn std::error::Err
                         "{} {}{}{}",
                         color::id(&dep_id),
                         color::muted_light("("),
-                        color::path(&dep.source),
+                        color::file(&dep.source),
                         color::muted_light(")"),
                     ));
                 }
@@ -85,7 +85,7 @@ pub async fn project(id: &str, json: bool) -> Result<(), Box<dyn std::error::Err
             let mut files = vec![];
 
             for file in &project.file_groups.get(group).unwrap().files {
-                files.push(color::path(file));
+                files.push(color::file(file));
             }
 
             term.render_entry_list(group, &files)?;

--- a/crates/cli/src/commands/project.rs
+++ b/crates/cli/src/commands/project.rs
@@ -103,8 +103,14 @@ mod tests {
     use crate::helpers::{create_test_command, get_assert_output, get_assert_stderr_output};
     use insta::assert_snapshot;
 
+    fn force_ansi_colors() {
+        std::env::set_var("CLICOLOR_FORCE", "1");
+    }
+
     #[test]
     fn unknown_project() {
+        force_ansi_colors();
+
         let assert = create_test_command("projects")
             .arg("project")
             .arg("unknown")
@@ -117,6 +123,8 @@ mod tests {
 
     #[test]
     fn empty_config() {
+        force_ansi_colors();
+
         let assert = create_test_command("projects")
             .arg("project")
             .arg("emptyConfig")
@@ -127,6 +135,8 @@ mod tests {
 
     #[test]
     fn no_config() {
+        force_ansi_colors();
+
         let assert = create_test_command("projects")
             .arg("project")
             .arg("noConfig")
@@ -137,6 +147,8 @@ mod tests {
 
     #[test]
     fn basic_config() {
+        force_ansi_colors();
+
         // with dependsOn and fileGroups
         let assert = create_test_command("projects")
             .arg("project")
@@ -148,6 +160,8 @@ mod tests {
 
     #[test]
     fn advanced_config() {
+        force_ansi_colors();
+
         // with project metadata
         let assert = create_test_command("projects")
             .arg("project")
@@ -159,6 +173,8 @@ mod tests {
 
     #[test]
     fn depends_on_paths() {
+        force_ansi_colors();
+
         // shows dependsOn paths when they exist
         let assert = create_test_command("projects")
             .arg("project")
@@ -170,6 +186,8 @@ mod tests {
 
     #[test]
     fn with_tasks() {
+        force_ansi_colors();
+
         let assert = create_test_command("projects")
             .arg("project")
             .arg("tasks")

--- a/crates/cli/src/commands/snapshots/moon_cli__commands__project__tests__advanced_config.snap
+++ b/crates/cli/src/commands/snapshots/moon_cli__commands__project__tests__advanced_config.snap
@@ -1,28 +1,27 @@
 ---
 source: crates/cli/src/commands/project.rs
-assertion_line: 157
+assertion_line: 171
 expression: get_assert_output(&assert)
-
 ---
 
 [38;5;16m[48;5;111m[1m ADVANCED [0m
 
-[38;5;248mID:[0m [38;5;111madvanced[0m
-[38;5;248mSource:[0m [38;5;36madvanced[0m
-[38;5;248mType:[0m Library
-[38;5;248mName:[0m Advanced
-[38;5;248mDescription:[0m Advanced example.
-[38;5;248mOwner:[0m Batman
-[38;5;248mMaintainers:[0m
+[38;5;248m[1mID[0m:[0m [38;5;111madvanced[0m
+[38;5;248m[1mSource[0m:[0m [38;5;36madvanced[0m
+[38;5;248m[1mType[0m:[0m Library
+[38;5;248m[1mName[0m:[0m Advanced
+[38;5;248m[1mDescription[0m:[0m Advanced example.
+[38;5;248m[1mOwner[0m:[0m Batman
+[38;5;248m[1mMaintainers[0m:[0m
  [38;5;239m-[0m Bruce Wayne
-[38;5;248mChannel:[0m #batcave
+[38;5;248m[1mChannel[0m:[0m #batcave
 
 [38;5;16m[48;5;15m[1m FILE GROUPS [0m
 
-[38;5;248msources:[0m
+[38;5;248m[1msources[0m:[0m
  [38;5;239m-[0m [38;5;36msrc/**/*[0m
  [38;5;239m-[0m [38;5;36mtypes/**/*[0m
-[38;5;248mtests:[0m
+[38;5;248m[1mtests[0m:[0m
  [38;5;239m-[0m [38;5;36mtests/**/*[0m
 
 

--- a/crates/cli/src/commands/snapshots/moon_cli__commands__project__tests__basic_config.snap
+++ b/crates/cli/src/commands/snapshots/moon_cli__commands__project__tests__basic_config.snap
@@ -1,14 +1,13 @@
 ---
 source: crates/cli/src/commands/project.rs
-assertion_line: 146
+assertion_line: 158
 expression: get_assert_output(&assert)
-
 ---
 
 [38;5;16m[48;5;111m[1m BASIC [0m
 
-[38;5;248mID:[0m [38;5;111mbasic[0m
-[38;5;248mSource:[0m [38;5;36mbasic[0m
+[38;5;248m[1mID[0m:[0m [38;5;111mbasic[0m
+[38;5;248m[1mSource[0m:[0m [38;5;36mbasic[0m
 
 [38;5;16m[48;5;15m[1m DEPENDS ON [0m
 
@@ -16,10 +15,10 @@ expression: get_assert_output(&assert)
 
 [38;5;16m[48;5;15m[1m FILE GROUPS [0m
 
-[38;5;248msources:[0m
+[38;5;248m[1msources[0m:[0m
  [38;5;239m-[0m [38;5;36msrc/**/*[0m
  [38;5;239m-[0m [38;5;36mtypes/**/*[0m
-[38;5;248mtests:[0m
+[38;5;248m[1mtests[0m:[0m
  [38;5;239m-[0m [38;5;36m**/*_test.rs[0m
 
 

--- a/crates/cli/src/commands/snapshots/moon_cli__commands__project__tests__depends_on_paths.snap
+++ b/crates/cli/src/commands/snapshots/moon_cli__commands__project__tests__depends_on_paths.snap
@@ -1,14 +1,13 @@
 ---
 source: crates/cli/src/commands/project.rs
-assertion_line: 168
+assertion_line: 184
 expression: get_assert_output(&assert)
-
 ---
 
 [38;5;16m[48;5;111m[1m FOO [0m
 
-[38;5;248mID:[0m [38;5;111mfoo[0m
-[38;5;248mSource:[0m [38;5;36mdeps/foo[0m
+[38;5;248m[1mID[0m:[0m [38;5;111mfoo[0m
+[38;5;248m[1mSource[0m:[0m [38;5;36mdeps/foo[0m
 
 [38;5;16m[48;5;15m[1m DEPENDS ON [0m
 
@@ -17,10 +16,10 @@ expression: get_assert_output(&assert)
 
 [38;5;16m[48;5;15m[1m FILE GROUPS [0m
 
-[38;5;248msources:[0m
+[38;5;248m[1msources[0m:[0m
  [38;5;239m-[0m [38;5;36msrc/**/*[0m
  [38;5;239m-[0m [38;5;36mtypes/**/*[0m
-[38;5;248mtests:[0m
+[38;5;248m[1mtests[0m:[0m
  [38;5;239m-[0m [38;5;36mtests/**/*[0m
 
 

--- a/crates/cli/src/commands/snapshots/moon_cli__commands__project__tests__empty_config.snap
+++ b/crates/cli/src/commands/snapshots/moon_cli__commands__project__tests__empty_config.snap
@@ -1,21 +1,20 @@
 ---
 source: crates/cli/src/commands/project.rs
-assertion_line: 125
+assertion_line: 133
 expression: get_assert_output(&assert)
-
 ---
 
 [38;5;16m[48;5;111m[1m EMPTYCONFIG [0m
 
-[38;5;248mID:[0m [38;5;111memptyConfig[0m
-[38;5;248mSource:[0m [38;5;36mempty-config[0m
+[38;5;248m[1mID[0m:[0m [38;5;111memptyConfig[0m
+[38;5;248m[1mSource[0m:[0m [38;5;36mempty-config[0m
 
 [38;5;16m[48;5;15m[1m FILE GROUPS [0m
 
-[38;5;248msources:[0m
+[38;5;248m[1msources[0m:[0m
  [38;5;239m-[0m [38;5;36msrc/**/*[0m
  [38;5;239m-[0m [38;5;36mtypes/**/*[0m
-[38;5;248mtests:[0m
+[38;5;248m[1mtests[0m:[0m
  [38;5;239m-[0m [38;5;36mtests/**/*[0m
 
 

--- a/crates/cli/src/commands/snapshots/moon_cli__commands__project__tests__no_config.snap
+++ b/crates/cli/src/commands/snapshots/moon_cli__commands__project__tests__no_config.snap
@@ -1,21 +1,20 @@
 ---
 source: crates/cli/src/commands/project.rs
-assertion_line: 135
+assertion_line: 145
 expression: get_assert_output(&assert)
-
 ---
 
 [38;5;16m[48;5;111m[1m NOCONFIG [0m
 
-[38;5;248mID:[0m [38;5;111mnoConfig[0m
-[38;5;248mSource:[0m [38;5;36mno-config[0m
+[38;5;248m[1mID[0m:[0m [38;5;111mnoConfig[0m
+[38;5;248m[1mSource[0m:[0m [38;5;36mno-config[0m
 
 [38;5;16m[48;5;15m[1m FILE GROUPS [0m
 
-[38;5;248msources:[0m
+[38;5;248m[1msources[0m:[0m
  [38;5;239m-[0m [38;5;36msrc/**/*[0m
  [38;5;239m-[0m [38;5;36mtypes/**/*[0m
-[38;5;248mtests:[0m
+[38;5;248m[1mtests[0m:[0m
  [38;5;239m-[0m [38;5;36mtests/**/*[0m
 
 

--- a/crates/cli/src/commands/snapshots/moon_cli__commands__project__tests__with_tasks.snap
+++ b/crates/cli/src/commands/snapshots/moon_cli__commands__project__tests__with_tasks.snap
@@ -1,26 +1,25 @@
 ---
 source: crates/cli/src/commands/project.rs
-assertion_line: 178
+assertion_line: 196
 expression: get_assert_output(&assert)
-
 ---
 
 [38;5;16m[48;5;111m[1m TASKS [0m
 
-[38;5;248mID:[0m [38;5;111mtasks[0m
-[38;5;248mSource:[0m [38;5;36mtasks[0m
+[38;5;248m[1mID[0m:[0m [38;5;111mtasks[0m
+[38;5;248m[1mSource[0m:[0m [38;5;36mtasks[0m
 
 [38;5;16m[48;5;15m[1m TASKS [0m
 
-[38;5;248mlint:[0m [38;5;183meslint --cache --report-unused-disable-directives[0m
-[38;5;248mtest:[0m [38;5;183mjest --cache --color[0m
+[38;5;248m[1mlint[0m:[0m [38;5;183meslint --cache --report-unused-disable-directives[0m
+[38;5;248m[1mtest[0m:[0m [38;5;183mjest --cache --color[0m
 
 [38;5;16m[48;5;15m[1m FILE GROUPS [0m
 
-[38;5;248msources:[0m
+[38;5;248m[1msources[0m:[0m
  [38;5;239m-[0m [38;5;36msrc/**/*[0m
  [38;5;239m-[0m [38;5;36mtypes/**/*[0m
-[38;5;248mtests:[0m
+[38;5;248m[1mtests[0m:[0m
  [38;5;239m-[0m [38;5;36mtests/**/*[0m
 
 

--- a/crates/error/src/lib.rs
+++ b/crates/error/src/lib.rs
@@ -9,25 +9,25 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum MoonError {
-    #[error("File system failure for <file_path>{0}</file_path>: {1}")]
+    #[error("File system failure for <path>{0}</path>: {1}")]
     FileSystem(PathBuf, #[source] IoError),
 
-    #[error("Failed to create a hard link from <file_path>{0}</file_path> to <file_path>{1}</file_path>.")]
+    #[error("Failed to create a hard link from <path>{0}</path> to <path>{1}</path>.")]
     HardLink(PathBuf, PathBuf),
 
-    #[error("Failed to parse <file_path>{0}</file_path>: {1}")]
+    #[error("Failed to parse <path>{0}</path>: {1}")]
     Json(PathBuf, #[source] JsonError),
 
     #[error("Network failure: {0}")]
     Network(#[source] IoError),
 
-    #[error("Network failure for <file_path>{0}</file_path>: {1}")]
+    #[error("Network failure for <path>{0}</path>: {1}")]
     NetworkWithHandle(PathBuf, #[source] IoError),
 
-    #[error("Path <file_path>{0}</file_path> contains invalid UTF-8 characters.")]
+    #[error("Path <path>{0}</path> contains invalid UTF-8 characters.")]
     PathInvalidUTF8(PathBuf),
 
-    #[error("Process failure for <path>{0}</path>: {1}")]
+    #[error("Process failure for <file>{0}</file>: {1}")]
     Process(String, #[source] IoError),
 
     #[error("Process <shell>{0}</shell> failed with a <symbol>{1}</symbol> exit code. {2}")]

--- a/crates/logger/Cargo.toml
+++ b/crates/logger/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-ansi_term = "0.12"
 chrono = "0.4"
+console = "0.15"
 fern = "0.6"
 log = "0.4"

--- a/crates/logger/src/color.rs
+++ b/crates/logger/src/color.rs
@@ -51,11 +51,11 @@ pub fn invalid(value: &str) -> String {
     paint(Color::Yellow as u8, value)
 }
 
-pub fn path(path: &str) -> String {
+pub fn file(path: &str) -> String {
     paint(Color::Teal as u8, path)
 }
 
-pub fn file_path(path: &Path) -> String {
+pub fn path(path: &Path) -> String {
     paint(Color::Cyan as u8, path.to_str().unwrap_or("<unknown>"))
 }
 

--- a/crates/logger/src/color.rs
+++ b/crates/logger/src/color.rs
@@ -1,7 +1,8 @@
 // Colors based on 4th column, except for gray:
 // https://upload.wikimedia.org/wikipedia/commons/1/15/Xterm_256color_chart.svg
 
-use ansi_term::Color::Fixed;
+pub use console::style;
+use console::{colors_enabled, pad_str, Alignment};
 use log::Level;
 use std::env;
 use std::path::Path;
@@ -27,7 +28,7 @@ pub fn paint(color: u8, value: &str) -> String {
         return value.to_owned();
     }
 
-    Fixed(color).paint(value).to_string()
+    style(value).color256(color).to_string()
 }
 
 pub fn muted(value: &str) -> String {
@@ -94,23 +95,18 @@ pub fn log_target(value: &str) -> String {
     if supports_color() >= 2 {
         let index = i32::abs(hash as i32) as usize % COLOR_LIST.len();
 
-        return Fixed(COLOR_LIST[index]).bold().paint(value).to_string();
+        return style(value).color256(COLOR_LIST[index]).to_string();
     }
 
     let index = i32::abs(hash as i32) as usize % COLOR_LIST_UNSUPPORTED.len();
 
-    Fixed(COLOR_LIST_UNSUPPORTED[index])
-        .bold()
-        .paint(value)
+    style(value)
+        .color256(COLOR_LIST_UNSUPPORTED[index])
         .to_string()
 }
 
 pub fn log_level(level: Level) -> String {
-    let mut msg = level.as_str().to_lowercase();
-
-    while msg.len() < 5 {
-        msg = [&msg, " "].concat();
-    }
+    let msg = String::from(pad_str(level.as_str(), 5, Alignment::Left, None)).to_lowercase();
 
     match level {
         // Only color these as we want them to stand out
@@ -153,6 +149,10 @@ pub fn supports_color() -> u8 {
         } else {
             return 1;
         }
+    }
+
+    if colors_enabled() {
+        return 2;
     }
 
     if env::var("CI").is_ok() {

--- a/crates/logger/src/color.rs
+++ b/crates/logger/src/color.rs
@@ -106,17 +106,13 @@ pub fn log_target(value: &str) -> String {
 }
 
 pub fn log_level(level: Level) -> String {
-    let msg = String::from(pad_str(level.as_str(), 5, Alignment::Left, None)).to_lowercase();
+    let msg = String::from(pad_str(level.as_str(), 5, Alignment::Right, None)).to_lowercase();
 
     match level {
         // Only color these as we want them to stand out
         Level::Error => paint(Color::Red as u8, &msg),
         Level::Warn => paint(Color::Yellow as u8, &msg),
-        // Just return as is
-        _ => msg,
-        // Level::Info => Color::White,
-        // Level::Debug => Color::Blue,
-        // Level::Trace => Color::Lime,
+        _ => muted(&msg),
     }
 }
 

--- a/crates/logger/src/lib.rs
+++ b/crates/logger/src/lib.rs
@@ -3,7 +3,8 @@ mod logger;
 
 pub use logger::Logger;
 
-// Re-export so that consumers dont need to install the log crate
+// Re-export so that consumers dont need to install these crates
+pub use console::{measure_text_width, pad_str, pad_str_with, strip_ansi_codes};
 pub use log::{debug, error, info, max_level, trace, warn, LevelFilter};
 
 pub fn logging_enabled() -> bool {

--- a/crates/logger/src/logger.rs
+++ b/crates/logger/src/logger.rs
@@ -16,11 +16,6 @@ impl Logger {
             return;
         }
 
-        #[cfg(windows)]
-        if std::env::consts::OS == "windows" {
-            ansi_term::enable_ansi_support().unwrap();
-        }
-
         Dispatch::new()
             .filter(|metadata| metadata.target().starts_with("moon"))
             .format(|out, message, record| {

--- a/crates/logger/src/logger.rs
+++ b/crates/logger/src/logger.rs
@@ -38,14 +38,16 @@ impl Logger {
                 }
 
                 let prefix = format!(
-                    "[{} {}]",
+                    "{}{} {}{}",
+                    color::muted("["),
                     color::log_level(record.level()),
-                    current_timestamp.format(date_format),
+                    color::muted(&current_timestamp.format(date_format).to_string()),
+                    color::muted("]"),
                 );
 
                 out.finish(format_args!(
                     "{} {} {}",
-                    color::muted(&prefix),
+                    prefix,
                     color::log_target(record.target()),
                     message
                 ));

--- a/crates/project/src/errors.rs
+++ b/crates/project/src/errors.rs
@@ -9,12 +9,12 @@ pub enum ProjectError {
     DependencyCycleDetected,
 
     #[error(
-        "Failed to validate <path>{0}/{}</path> configuration file.\n\n<muted>{0}</muted>",
+        "Failed to validate <file>{0}/{}</file> configuration file.\n\n<muted>{0}</muted>",
         constants::CONFIG_PROJECT_FILENAME
     )]
     InvalidConfigFile(String, ValidationErrors),
 
-    #[error("Failed to parse and open <path>{0}/package.json</path>: {1}")]
+    #[error("Failed to parse and open <file>{0}/package.json</file>: {1}")]
     InvalidPackageJson(String, String),
 
     #[error(
@@ -22,14 +22,14 @@ pub enum ProjectError {
     )]
     InvalidTargetFormat(String),
 
-    #[error("Failed to parse and open <path>{0}/{1}</path>: {2}")]
+    #[error("Failed to parse and open <file>{0}/{1}</file>: {2}")]
     InvalidTsConfigJson(String, String, String),
 
-    #[error("No project exists at path <path>{0}</path>.")]
+    #[error("No project exists at path <file>{0}</file>.")]
     MissingProject(String),
 
     #[error(
-        "Task outputs do not support file globs. Found <file_path>{0}</file_path> in <target>{1}</target>."
+        "Task outputs do not support file globs. Found <path>{0}</path> in <target>{1}</target>."
     )]
     NoOutputGlob(PathBuf, String),
 

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -30,8 +30,8 @@ fn load_project_config(
     trace!(
         target: "moon:project",
         "Attempting to find {} in {}",
-        color::path(CONFIG_PROJECT_FILENAME),
-        color::file_path(project_root),
+        color::file(CONFIG_PROJECT_FILENAME),
+        color::path(project_root),
     );
 
     if config_path.exists() {
@@ -204,9 +204,9 @@ impl Project {
         debug!(
             target: &format!("moon:project:{}", id),
             "Loading project from {} (id = {}, path = {})",
-            color::file_path(&root),
+            color::path(&root),
             color::id(id),
-            color::path(source),
+            color::file(source),
         );
 
         if !root.exists() {
@@ -278,7 +278,7 @@ impl Project {
             trace!(
                 target: &format!("moon:project:{}", self.id),
                 "Is affected by {} = {}",
-                color::file_path(file),
+                color::path(file),
                 if affected {
                     color::success("true")
                 } else {
@@ -301,8 +301,8 @@ impl Project {
         trace!(
             target: &format!("moon:project:{}", self.id),
             "Attempting to find {} in {}",
-            color::path("package.json"),
-            color::file_path(&self.root),
+            color::file("package.json"),
+            color::path(&self.root),
         );
 
         if package_path.exists() {
@@ -328,8 +328,8 @@ impl Project {
         trace!(
             target: &format!("moon:project:{}", self.id),
             "Attempting to find {} in {}",
-            color::path(tsconfig_name),
-            color::file_path(&self.root),
+            color::file(tsconfig_name),
+            color::path(&self.root),
         );
 
         if tsconfig_path.exists() {

--- a/crates/project/src/task.rs
+++ b/crates/project/src/task.rs
@@ -247,7 +247,7 @@ impl Task {
             "Checking if affected using input files: {}",
             self.input_paths
                 .iter()
-                .map(|p| color::file_path(p))
+                .map(|p| color::path(p))
                 .collect::<Vec<_>>()
                 .join(", ")
         );
@@ -261,7 +261,7 @@ impl Task {
                 "Checking if affected using input globs: {}",
                 self.input_globs
                     .iter()
-                    .map(|p| color::path(p))
+                    .map(|p| color::file(p))
                     .collect::<Vec<_>>()
                     .join(", ")
             );
@@ -277,7 +277,7 @@ impl Task {
             trace!(
                 target: &format!("moon:project:{}", self.target),
                 "Is affected by {} = {}",
-                color::file_path(file),
+                color::path(file),
                 if affected {
                     color::success("true")
                 } else {

--- a/crates/project/src/token.rs
+++ b/crates/project/src/token.rs
@@ -150,7 +150,7 @@ impl<'a> TokenResolver<'a> {
                 warn!(
                     target: "moon:project:token",
                     "Found a token function in {} with other content. Token functions *must* be used literally as the only value.",
-                    color::path(value)
+                    color::file(value)
                 );
             }
         }
@@ -251,7 +251,7 @@ impl<'a> TokenResolver<'a> {
             "Resolving token variable {} for {} value {}",
             color::id(token),
             self.context.context_label(),
-            color::path(value)
+            color::file(value)
         );
 
         let (project_id, task_id) = Target::parse(&task.target)?;

--- a/crates/terminal/Cargo.toml
+++ b/crates/terminal/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2021"
 
 [dependencies]
 moon_logger = { path = "../logger" }
-ansi_term = "0.12"
 console = "0.15"
 lazy_static = "1.4"
 regex = "1.5"

--- a/crates/terminal/src/helpers.rs
+++ b/crates/terminal/src/helpers.rs
@@ -23,10 +23,10 @@ pub fn replace_style_tokens(value: &str) -> String {
         let inner = caps.get(2).map_or("", |m| m.as_str());
 
         match token {
-            "file_path" => color::file_path(Path::new(inner)),
+            "file" => color::file(inner),
             "id" => color::id(inner),
             "muted" => color::muted_light(inner),
-            "path" => color::path(inner),
+            "path" => color::path(Path::new(inner)),
             "target" => color::target(inner),
             "shell" => color::shell(inner),
             "symbol" => color::symbol(inner),
@@ -45,6 +45,8 @@ mod test {
 
         #[test]
         fn renders_ansi() {
+            std::env::set_var("CLICOLOR_FORCE", "1");
+
             let list = vec!["file_path", "muted", "id", "path", "shell", "symbol"];
 
             for token in list {
@@ -61,6 +63,8 @@ mod test {
 
         #[test]
         fn renders_multiple_ansi() {
+            std::env::set_var("CLICOLOR_FORCE", "1");
+
             assert_ne!(
                 replace_style_tokens("<muted>Before</muted> <id>inner</id> <symbol>after</symbol>"),
                 "Before inner after"

--- a/crates/terminal/src/output.rs
+++ b/crates/terminal/src/output.rs
@@ -6,10 +6,10 @@ const STEP_CHAR: &str = "▪";
 pub fn label_moon() -> String {
     format!(
         "{}{}{}{}",
-        style(color::paint(57, "M")).bold(),
-        style(color::paint(63, "O")).bold(),
-        style(color::paint(69, "O")).bold(),
-        style(color::paint(75, "N")).bold(),
+        style("M").color256(57).bold(),
+        style("O").color256(63).bold(),
+        style("O").color256(69).bold(),
+        style("N").color256(75).bold(),
     )
 }
 

--- a/crates/toolchain/src/errors.rs
+++ b/crates/toolchain/src/errors.rs
@@ -3,7 +3,9 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum ToolchainError {
-    #[error("Shashum check has failed for <file_path>{0}</file_path>, which was downloaded from <url>{1}</url>.")]
+    #[error(
+        "Shashum check has failed for <file>{0}</file>, which was downloaded from <url>{1}</url>."
+    )]
     InvalidShasum(
         String, // Download path
         String, // URL

--- a/crates/toolchain/src/helpers.rs
+++ b/crates/toolchain/src/helpers.rs
@@ -45,7 +45,7 @@ pub fn get_file_sha256_hash(path: &Path) -> Result<String, ToolchainError> {
     trace!(
         target: "moon:toolchain",
         "Calculating sha256 for file {} -> {}",
-        color::file_path(path),
+        color::path(path),
         color::symbol(&hash)
     );
 
@@ -71,7 +71,7 @@ pub async fn download_file_from_url(url: &str, dest: &Path) -> Result<(), Toolch
     trace!(
         target: "moon:toolchain",
         "Downloading file to {}",
-        color::file_path(dest.parent().unwrap()),
+        color::path(dest.parent().unwrap()),
     );
 
     // Ensure parent directories exist

--- a/crates/toolchain/src/toolchain.rs
+++ b/crates/toolchain/src/toolchain.rs
@@ -21,7 +21,7 @@ async fn create_dir(dir: &Path) -> Result<(), ToolchainError> {
         fs::create_dir_all(dir).await?;
     }
 
-    trace!(target: "moon:toolchain", "Created directory {}", color::file_path(dir));
+    trace!(target: "moon:toolchain", "Created directory {}", color::path(dir));
 
     Ok(())
 }
@@ -63,7 +63,7 @@ impl Toolchain {
         debug!(
             target: "moon:toolchain",
             "Creating toolchain at {}",
-            color::file_path(&dir)
+            color::path(&dir)
         );
 
         create_dir(&dir).await?;
@@ -226,7 +226,7 @@ impl Toolchain {
 
                 trace!(
                     target: "moon:toolchain", "Deleted download {}",
-                    color::file_path(download_path)
+                    color::path(download_path)
                 );
             }
         }
@@ -239,7 +239,7 @@ impl Toolchain {
             trace!(
                 target: "moon:toolchain",
                 "Deleted installation {}",
-                color::file_path(install_dir)
+                color::path(install_dir)
             );
         }
 

--- a/crates/toolchain/src/tools/node.rs
+++ b/crates/toolchain/src/tools/node.rs
@@ -150,7 +150,7 @@ impl NodeTool {
         debug!(
             target: "moon:toolchain:node",
             "Creating tool at {}",
-            color::file_path(&bin_path)
+            color::path(&bin_path)
         );
 
         Ok(NodeTool {
@@ -244,7 +244,7 @@ impl Tool for NodeTool {
             target: "moon:toolchain:node",
             "Downloading binary from {} to {}",
             color::url(&download_url),
-            color::file_path(&self.download_path)
+            color::path(&self.download_path)
         );
 
         // Download the SHASUMS256.txt file
@@ -305,7 +305,7 @@ impl Tool for NodeTool {
         debug!(
             target: "moon:toolchain:node",
             "Unpacked and installed to {}",
-            color::file_path(install_dir)
+            color::path(install_dir)
         );
 
         Ok(())

--- a/crates/toolchain/src/tools/npm.rs
+++ b/crates/toolchain/src/tools/npm.rs
@@ -38,7 +38,7 @@ impl NpmTool {
         debug!(
             target: "moon:toolchain:npm",
             "Creating tool at {}",
-            color::file_path(&bin_path)
+            color::path(&bin_path)
         );
 
         Ok(NpmTool {

--- a/crates/toolchain/src/tools/pnpm.rs
+++ b/crates/toolchain/src/tools/pnpm.rs
@@ -33,7 +33,7 @@ impl PnpmTool {
         debug!(
             target: "moon:toolchain:pnpm",
             "Creating tool at {}",
-            color::file_path(&bin_path)
+            color::path(&bin_path)
         );
 
         Ok(PnpmTool {

--- a/crates/toolchain/src/tools/yarn.rs
+++ b/crates/toolchain/src/tools/yarn.rs
@@ -33,7 +33,7 @@ impl YarnTool {
         debug!(
             target: "moon:toolchain:yarn",
             "Creating tool at {}",
-            color::file_path(&bin_path)
+            color::path(&bin_path)
         );
 
         Ok(YarnTool {

--- a/crates/utils/src/process.rs
+++ b/crates/utils/src/process.rs
@@ -32,7 +32,7 @@ fn log_command_info(command: &Command) {
             target: "moon:utils",
             "Running command {} (in {})",
             color::shell(&command_line),
-            color::file_path(cwd),
+            color::path(cwd),
         );
     } else {
         trace!(

--- a/crates/workspace/src/actions/install_node_deps.rs
+++ b/crates/workspace/src/actions/install_node_deps.rs
@@ -27,7 +27,7 @@ pub async fn install_node_deps(
         debug!(
             target: TARGET,
             "Adding engines version constraint to root {}",
-            color::path("package.json")
+            color::file("package.json")
         );
     }
 
@@ -40,7 +40,7 @@ pub async fn install_node_deps(
         debug!(
             target: TARGET,
             "Syncing Node.js version to root {}",
-            color::path(&rc_name)
+            color::file(&rc_name)
         );
     }
 

--- a/crates/workspace/src/actions/sync_project.rs
+++ b/crates/workspace/src/actions/sync_project.rs
@@ -31,7 +31,7 @@ pub async fn sync_project(
                     target: TARGET,
                     "Syncing {} as a project reference to the root {}",
                     color::id(project_id),
-                    color::path(tsconfig_root_name)
+                    color::file(tsconfig_root_name)
                 );
 
                 tsconfig.save().await?;
@@ -65,7 +65,7 @@ pub async fn sync_project(
                         "Syncing {} as a dependency to {}'s {}",
                         color::id(&dep_id),
                         color::id(project_id),
-                        color::path("package.json")
+                        color::file("package.json")
                     );
 
                     package.save().await?;
@@ -89,7 +89,7 @@ pub async fn sync_project(
                         "Syncing {} as a project reference to {}'s {}",
                         color::id(&dep_id),
                         color::id(project_id),
-                        color::path(tsconfig_branch_name)
+                        color::file(tsconfig_branch_name)
                     );
 
                     tsconfig.save().await?;

--- a/crates/workspace/src/errors.rs
+++ b/crates/workspace/src/errors.rs
@@ -6,7 +6,7 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum WorkspaceError {
-    #[error("A dependency cycle has been detected for <path>{0}</path>.")]
+    #[error("A dependency cycle has been detected for <file>{0}</file>.")]
     DepGraphCycleDetected(String),
 
     #[error("Unknown node {0} found in dependency graph. How did this get here?")]
@@ -16,40 +16,40 @@ pub enum WorkspaceError {
     ActionRunnerFailure(String),
 
     #[error(
-        "Unable to determine workspace root. Please create a <path>{}</path> configuration folder.",
+        "Unable to determine workspace root. Please create a <file>{}</file> configuration folder.",
         constants::CONFIG_DIRNAME
     )]
     MissingConfigDir,
 
     #[error(
-        "Unable to locate a root <path>package.json</path>. Please create one alongside the <path>{}</path> configuration folder.",
+        "Unable to locate a root <file>package.json</file>. Please create one alongside the <file>{}</file> configuration folder.",
         constants::CONFIG_DIRNAME
     )]
     MissingPackageJson,
 
     #[error(
-        "Unable to locate <path>{}/{}</path> configuration file.",
+        "Unable to locate <file>{}/{}</file> configuration file.",
         constants::CONFIG_DIRNAME,
         constants::CONFIG_WORKSPACE_FILENAME
     )]
     MissingWorkspaceConfigFile,
 
     #[error(
-        "Unable to locate <path>{}/{}</path> configuration file.",
+        "Unable to locate <file>{}/{}</file> configuration file.",
         constants::CONFIG_DIRNAME,
         constants::CONFIG_PROJECT_FILENAME
     )]
     MissingGlobalProjectConfigFile,
 
     #[error(
-        "Failed to validate <path>{}/{}</path> configuration file.\n\n<muted>{0}</muted>",
+        "Failed to validate <file>{}/{}</file> configuration file.\n\n<muted>{0}</muted>",
         constants::CONFIG_DIRNAME,
         constants::CONFIG_WORKSPACE_FILENAME
     )]
     InvalidWorkspaceConfigFile(ValidationErrors),
 
     #[error(
-        "Failed to validate <path>{}/{}</path> configuration file.\n\n<muted>{0}</muted>",
+        "Failed to validate <file>{}/{}</file> configuration file.\n\n<muted>{0}</muted>",
         constants::CONFIG_DIRNAME,
         constants::CONFIG_PROJECT_FILENAME
     )]

--- a/crates/workspace/src/vcs/mod.rs
+++ b/crates/workspace/src/vcs/mod.rs
@@ -5,7 +5,6 @@ use crate::errors::WorkspaceError;
 use async_trait::async_trait;
 use git::Git;
 use moon_config::{VcsManager as VM, WorkspaceConfig};
-use moon_logger::{color, debug};
 use std::collections::{BTreeMap, HashSet};
 use std::path::Path;
 use svn::Svn;
@@ -78,12 +77,6 @@ impl VcsManager {
         let vcs_config = &config.vcs;
         let manager = &vcs_config.manager;
         let default_branch = &vcs_config.default_branch;
-
-        debug!(
-            target: "moon:workspace",
-            "Using {} version control system",
-            color::symbol(&format!("{:?}", manager).to_lowercase())
-        );
 
         match manager {
             VM::Svn => Box::new(Svn::new(default_branch, working_dir)),

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -18,7 +18,7 @@ fn find_workspace_root(current_dir: PathBuf) -> Option<PathBuf> {
     trace!(
         target: "moon:workspace",
         "Attempting to find workspace root at {}",
-        color::file_path(&current_dir),
+        color::path(&current_dir),
     );
 
     if config_dir.exists() {
@@ -42,13 +42,13 @@ fn load_global_project_config(root_dir: &Path) -> Result<GlobalProjectConfig, Wo
     trace!(
         target: "moon:workspace",
         "Attempting to find {} in {}",
-        color::path(
+        color::file(
             &format!("{}/{}",
                 constants::CONFIG_DIRNAME,
                 constants::CONFIG_PROJECT_FILENAME,
             )
         ),
-        color::file_path(root_dir)
+        color::path(root_dir)
     );
 
     if !config_path.exists() {
@@ -70,13 +70,13 @@ fn load_workspace_config(root_dir: &Path) -> Result<WorkspaceConfig, WorkspaceEr
     trace!(
         target: "moon:workspace",
         "Attempting to find {} in {}",
-        color::path(
+        color::file(
             &format!("{}/{}",
                 constants::CONFIG_DIRNAME,
                 constants::CONFIG_WORKSPACE_FILENAME,
             )
         ),
-        color::file_path(root_dir)
+        color::path(root_dir)
     );
 
     if !config_path.exists() {
@@ -122,8 +122,8 @@ impl Workspace {
         debug!(
             target: "moon:workspace",
             "Creating workspace at {} (from working directory {})",
-            color::file_path(&root_dir),
-            color::file_path(&working_dir)
+            color::path(&root_dir),
+            color::path(&working_dir)
         );
 
         // Load configs
@@ -157,8 +157,8 @@ impl Workspace {
         trace!(
             target: "moon:workspace",
             "Attempting to find {} in {}",
-            color::path("package.json"),
-            color::file_path(&self.root),
+            color::file("package.json"),
+            color::path(&self.root),
         );
 
         if !package_json_path.exists() {
@@ -178,8 +178,8 @@ impl Workspace {
         trace!(
             target: "moon:workspace",
             "Attempting to find {} in {}",
-            color::path(tsconfig_name),
-            color::file_path(&self.root),
+            color::file(tsconfig_name),
+            color::path(&self.root),
         );
 
         if !tsconfig_json_path.exists() {


### PR DESCRIPTION
We were using 2 crates to accomplish this, so this standardizes on the `console` crate.